### PR TITLE
3rd draft of profile set up

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:pronto/screens/onboarding/splash_screen.dart';
+import 'package:pronto/screens/onboarding/welcome_screen.dart';
+import 'package:pronto/screens/home_screen.dart';
+import 'package:pronto/screens/profile_setup/personal_details_screen.dart';
+import 'package:pronto/screens/profile_setup/designation_screen.dart';
+import 'package:pronto/screens/profile_setup/disabilities_screen.dart';
+import 'package:pronto/screens/profile_setup/location_screen.dart';
+import 'package:pronto/screens/profile_setup/intro_screen.dart';
+import 'package:pronto/screens/profile_setup/skills_screen.dart';
+import 'package:pronto/screens/profile_setup/social_screen.dart';
+import 'package:pronto/screens/profile_setup/resume_screen.dart';
+import 'package:pronto/screens/profile_setup/education_screen.dart';
+import 'package:pronto/screens/profile_setup/work_screen.dart';
+import 'package:pronto/screens/profile_setup/project_screen.dart';
+import 'package:pronto/screens/profile_setup/award_screen.dart';
 import 'firebase_options.dart';
 
 void main() async {
@@ -12,15 +28,14 @@ void main() async {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'pronto',
       theme: ThemeData(
-        primaryColor: Color(0xFFFF5844),
+        primaryColor: Color(0xFF0057B7),
         colorScheme: ColorScheme.fromSwatch().copyWith(
-          primary: Color(0xFFFF5844),
+          primary: Color(0xFF0057B7),
           secondary: Color(0xFFA6D3F2),
         ),
         textTheme: const TextTheme(
@@ -33,93 +48,225 @@ class MyApp extends StatelessWidget {
           labelSmall: TextStyle(fontSize: 10, fontFamily: 'Inter'),
         ),
       ),
-      home: const SplashScreen(),
+      debugShowCheckedModeBanner: false,
+      // Set up named routes with arguments
+      initialRoute: '/',
+      onGenerateRoute: (settings) {
+        switch (settings.name) {
+          case '/':
+            return MaterialPageRoute(builder: (context) => const AuthWrapper());
+          case '/welcome':
+            return MaterialPageRoute(
+              builder: (context) => const WelcomeScreen(),
+            );
+          case '/home':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => HomeScreen(userId: userId),
+            );
+          case '/personal-details':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => PersonalDetailsScreen(userId: userId),
+            );
+          case '/designation':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => DesignationScreen(userId: userId),
+            );
+          case '/disabilities':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => DisabilityScreen(userId: userId),
+            );
+          case '/location':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => LocationScreen(userId: userId),
+            );
+          case '/intro':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => IntroScreen(userId: userId),
+            );
+          case '/skills':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => SkillsScreen(userId: userId),
+            );
+          case '/social':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => SocialsScreen(userId: userId),
+            );
+          case '/resume':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => ResumeScreen(userId: userId),
+            );
+          case '/education':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => EducationScreen(userId: userId),
+            );
+          case '/work':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => WorkExperienceScreen(userId: userId),
+            );
+          case '/project':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => ProjectExperienceScreen(userId: userId),
+            );
+          case '/award':
+            final String userId = settings.arguments as String;
+            return MaterialPageRoute(
+              builder: (context) => AwardsScreen(userId: userId),
+            );
+          default:
+            return MaterialPageRoute(
+              builder: (context) => const WelcomeScreen(),
+            );
+        }
+      },
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+class AuthWrapper extends StatelessWidget {
+  const AuthWrapper({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+    return StreamBuilder<User?>(
+      stream: FirebaseAuth.instance.authStateChanges(),
+      builder: (context, snapshot) {
+        // Show loading screen while checking auth state
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const SplashScreen();
+        }
+        // User is not signed in
+        if (snapshot.data == null) {
+          return const WelcomeScreen();
+        }
+        // User is signed in, check onboarding completion
+        return OnboardingChecker(user: snapshot.data!);
+      },
     );
+  }
+}
+
+class OnboardingChecker extends StatelessWidget {
+  final User user;
+
+  const OnboardingChecker({super.key, required this.user});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<DocumentSnapshot>(
+      future: FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .get(),
+      builder: (context, snapshot) {
+        // Show loading screen while fetching user data
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const SplashScreen();
+        }
+        // Handle error
+        if (snapshot.hasError) {
+          return const WelcomeScreen();
+        }
+        // User document doesn't exist or no data - shouldn't happen after signup
+        if (!snapshot.hasData || !snapshot.data!.exists) {
+          return const WelcomeScreen();
+        }
+        // User document exists, check completed steps
+        final userData = snapshot.data!.data() as Map<String, dynamic>;
+        final int completedSteps =
+            userData['completedSteps'] ?? 1; // Default to 1 after signup
+
+        // Navigate based on completed steps
+        return _getScreenForStep(completedSteps);
+      },
+    );
+  }
+
+  Widget _getScreenForStep(int completedSteps) {
+    final String userId = user.uid;
+
+    switch (completedSteps) {
+      case 1:
+        return PersonalDetailsScreen(userId: userId);
+      case 2:
+        return DesignationScreen(userId: userId);
+      case 3:
+        return DisabilityScreen(userId: userId);
+      case 4:
+        return LocationScreen(userId: userId);
+      case 5:
+        return IntroScreen(userId: userId);
+      case 6:
+        return SkillsScreen(userId: userId);
+      case 7:
+        return SocialsScreen(userId: userId);
+      case 8:
+        return ResumeScreen(userId: userId);
+      case 9:
+        return EducationScreen(userId: userId);
+      case 10:
+        return WorkExperienceScreen(userId: userId);
+      case 11:
+        return ProjectExperienceScreen(userId: userId);
+      case 12:
+        return AwardsScreen(userId: userId);
+      default:
+        return HomeScreen(userId: userId);
+    }
+  }
+}
+
+// Navigation Helper Class
+class NavigationHelper {
+  static final GlobalKey<NavigatorState> navigatorKey =
+      GlobalKey<NavigatorState>();
+
+  // Navigate to a named route
+  static Future<dynamic> navigateTo(String routeName, {Object? arguments}) {
+    return navigatorKey.currentState!.pushNamed(
+      routeName,
+      arguments: arguments,
+    );
+  }
+
+  // Replace current route with a new one
+  static Future<dynamic> navigateAndReplace(
+    String routeName, {
+    Object? arguments,
+  }) {
+    return navigatorKey.currentState!.pushReplacementNamed(
+      routeName,
+      arguments: arguments,
+    );
+  }
+
+  // Clear all routes and navigate to a new one
+  static Future<dynamic> navigateAndClearStack(
+    String routeName, {
+    Object? arguments,
+  }) {
+    return navigatorKey.currentState!.pushNamedAndRemoveUntil(
+      routeName,
+      (Route<dynamic> route) => false,
+      arguments: arguments,
+    );
+  }
+
+  // Go back to previous screen
+  static void goBack() {
+    if (navigatorKey.currentState!.canPop()) {
+      navigatorKey.currentState!.pop();
+    }
   }
 }

--- a/lib/screens/auth/sign_in_screen.dart
+++ b/lib/screens/auth/sign_in_screen.dart
@@ -32,14 +32,19 @@ class _SigninScreenState extends State<SigninScreen> {
     });
 
     try {
-      await FirebaseAuth.instance.signInWithEmailAndPassword(
-        email: _emailController.text.trim(),
-        password: _passwordController.text,
-      );
+      UserCredential userCredential = await FirebaseAuth.instance
+          .signInWithEmailAndPassword(
+            email: _emailController.text.trim(),
+            password: _passwordController.text,
+          );
 
       if (mounted) {
         // Navigate to main app
-        Navigator.pushReplacementNamed(context, '/home');
+        Navigator.pushReplacementNamed(
+          context,
+          '/home',
+          arguments: userCredential.user!.uid,
+        );
       }
     } on FirebaseAuthException catch (e) {
       String message = 'An error occurred. Please try again.';

--- a/lib/screens/auth/sign_up_screen.dart
+++ b/lib/screens/auth/sign_up_screen.dart
@@ -50,6 +50,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
       // Save user document to Firestore
       await FirebaseFirestore.instance.collection('users').doc(userId).set({
         'email': user?.email,
+        'completedSteps': 1,
         'createdAt': FieldValue.serverTimestamp(),
       });
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,15 +1,36 @@
 import 'package:flutter/material.dart';
-import 'profile_setup/project_screen.dart'; // Adjust the import path as needed
+import 'package:firebase_auth/firebase_auth.dart';
+import 'profile_setup/project_screen.dart';
+import 'onboarding/welcome_screen.dart';
 
 class HomeScreen extends StatelessWidget {
   final String? userId;
 
   const HomeScreen({super.key, required this.userId});
 
+  void _logout(BuildContext context) async {
+    await FirebaseAuth.instance.signOut();
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (context) => const WelcomeScreen()),
+      (route) => false,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Home Screen'), centerTitle: true),
+      appBar: AppBar(
+        title: const Text('Home Screen'),
+        centerTitle: true,
+        automaticallyImplyLeading: false,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () => _logout(context),
+            tooltip: 'Log Out',
+          ),
+        ],
+      ),
       body: Center(
         child: ElevatedButton(
           onPressed: () {

--- a/lib/screens/profile_setup/award_screen.dart
+++ b/lib/screens/profile_setup/award_screen.dart
@@ -61,6 +61,7 @@ class _AwardsScreenState extends State<AwardsScreen> {
                 .collection('awards')
                 .add({
                   ...award,
+                  'completedSteps': 12,
                   'createdAt': FieldValue.serverTimestamp(),
                   'updatedAt': FieldValue.serverTimestamp(),
                 });
@@ -138,7 +139,7 @@ class _AwardsScreenState extends State<AwardsScreen> {
           .collection('users')
           .doc(widget.userId)
           .update({
-            'completedSteps': 12,
+            'completedSteps': 13,
             'updatedAt': FieldValue.serverTimestamp(),
           });
 

--- a/lib/screens/profile_setup/intro_screen.dart
+++ b/lib/screens/profile_setup/intro_screen.dart
@@ -40,7 +40,7 @@ class _IntroScreenState extends State<IntroScreen> {
           .collection('users')
           .doc(widget.userId)
           .set({
-            'selfIntroduction': {'introduction': _introController.text},
+            'selfIntroduction': _introController.text,
             'completedSteps': 3, // Assuming this is step 3 in your flow
             'updatedAt': FieldValue.serverTimestamp(),
           }, SetOptions(merge: true));

--- a/lib/screens/profile_setup/resume_screen.dart
+++ b/lib/screens/profile_setup/resume_screen.dart
@@ -198,11 +198,33 @@ class _ResumeScreenState extends State<ResumeScreen> {
             child: const Text('Cancel'),
           ),
           TextButton(
-            onPressed: () {
+            onPressed: () async {
+              final fileUrl = _resumes[type]?['url'];
+
               setState(() {
                 _resumes.remove(type);
               });
+
               Navigator.pop(context);
+
+              // Delete from Firebase Storage
+              if (fileUrl != null && fileUrl.isNotEmpty) {
+                try {
+                  final ref = FirebaseStorage.instance.refFromURL(fileUrl);
+                  await ref.delete();
+                  print('File: $fileUrl deleted successfully');
+                } catch (e) {
+                  print('Error deleting file: $e');
+                  if (mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('Error deleting file: $e'),
+                        backgroundColor: Colors.red,
+                      ),
+                    );
+                  }
+                }
+              }
             },
             child: const Text('Remove', style: TextStyle(color: Colors.red)),
           ),

--- a/lib/screens/profile_setup/skills_screen.dart
+++ b/lib/screens/profile_setup/skills_screen.dart
@@ -217,15 +217,14 @@ class _SkillsScreenState extends State<SkillsScreen> {
                   ),
                   Padding(
                     padding: const EdgeInsets.only(right: 8.0),
-                    child: ElevatedButton(
+                    child: TextButton(
                       onPressed: _addCustomSkill,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: AppColors.primary,
+                      style: TextButton.styleFrom(
                         minimumSize: const Size(60, 40),
                       ),
                       child: const Text(
                         'Add',
-                        style: TextStyle(color: Colors.white),
+                        style: TextStyle(color: AppColors.primary),
                       ),
                     ),
                   ),

--- a/lib/screens/profile_setup/social_screen.dart
+++ b/lib/screens/profile_setup/social_screen.dart
@@ -87,7 +87,7 @@ class _SocialsScreenState extends State<SocialsScreen> {
               ),
               const SizedBox(height: 8),
               Text(
-                'Link your professional and portfolio accounts (optional)',
+                'Link your professional and portfolio accounts',
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   color: AppColors.textSecondary,
                 ),


### PR DESCRIPTION
- Modified main.dart file: When the user first enters the app…
    - If he’s previously signed in, he will be navigated to home
    - If he’s not signed in, he will be navigated to the welcome page
    - If he has created an account but has yet to finish the onboarding screen, we check his
    completedSteps from his Firebase and navigate him to the relevant screen e.g. if completedSteps = 1,
navigate to personal_details screen
- Refined UI of profile set up screens
- Delete pdf from Firebase Storage (to save space) when users click remove
- Fixed Sign in to pass userId to Home Screen
- Added log out button in Home Screen to test authentication