### PR TITLE
Applicant Applications Page: search bar, filters and application

### DIFF
--- a/lib/models/application_model.dart
+++ b/lib/models/application_model.dart
@@ -1,37 +1,62 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-
 class Application {
-  String applicationID;
-  String jobID;
-  String status;
-  DateTime submittedAt;
-  String rejectionReason;
+  final String applicationID;
+  final String jobID;
+  final String status;
+  final DateTime appliedAt;
+  final String? resumeUrl;
+  final String? rejectionReason;
+  final bool favorite;
 
   Application({
     required this.applicationID,
     required this.jobID,
     required this.status,
-    required this.submittedAt,
-    required this.rejectionReason,
+    required this.appliedAt,
+    this.resumeUrl,
+    this.rejectionReason,
+    required this.favorite,
   });
+
+  factory Application.fromMap(Map<String, dynamic> map, String docId) {
+    return Application(
+      applicationID: docId,
+      jobID: map['jobId'] ?? '',
+      status: map['status'] ?? 'applied',
+      appliedAt: map['appliedAt']?.toDate() ?? DateTime.now(),
+      resumeUrl: map['resumeUrl'],
+      rejectionReason: map['rejectionReason'],
+      favorite: map['favorite'] ?? false,
+    );
+  }
 
   Map<String, dynamic> toMap() {
     return {
-      'applicationID': applicationID,
       'jobID': jobID,
       'status': status,
-      'submittedAt': Timestamp.fromDate(submittedAt),
+      'appliedAt': appliedAt,
+      'resumeUrl': resumeUrl,
       'rejectionReason': rejectionReason,
+      'favorite': favorite,
     };
   }
 
-  factory Application.fromMap(Map<String, dynamic> map) {
+  Application copyWith({
+    String? applicationID,
+    String? jobID,
+    String? status,
+    DateTime? appliedAt,
+    String? resumeUrl,
+    String? rejectionReason,
+    bool? favorite,
+  }) {
     return Application(
-      applicationID: map['applicationID'] ?? '',
-      jobID: map['jobID'] ?? '',
-      status: map['status'] ?? '',
-      submittedAt: (map['submittedAt'] as Timestamp).toDate(),
-      rejectionReason: map['rejectionReason'] ?? '',
+      applicationID: applicationID ?? this.applicationID,
+      jobID: jobID ?? this.jobID,
+      status: status ?? this.status,
+      appliedAt: appliedAt ?? this.appliedAt,
+      resumeUrl: resumeUrl ?? this.resumeUrl,
+      rejectionReason: rejectionReason ?? this.rejectionReason,
+      favorite: favorite ?? this.favorite,
     );
   }
 }

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -90,7 +90,15 @@ class UserModel {
     };
   }
 
-  factory UserModel.fromMap(Map<String, dynamic> map) {
+  factory UserModel.fromMap(
+    Map<String, dynamic> map, {
+    required List<Application> applications,
+    required List<Notification> notifications,
+    required List<Education> education,
+    required List<WorkExperience> workExperience,
+    required List<ProjectExperience> projectExperience,
+    required List<Award> awards,
+  }) {
     return UserModel(
       userID: map['userID'],
       name: map['name'] ?? '',
@@ -111,33 +119,12 @@ class UserModel {
       linkedIn: map['linkedIn'],
       gitHub: map['gitHub'],
       resumes: Map<String, String>.from(map['resumes'] ?? {}),
-      education:
-          (map['education'] as List?)
-              ?.map((e) => Education.fromMap(e))
-              .toList() ??
-          [],
-      workExperience:
-          (map['workExperience'] as List?)
-              ?.map((e) => WorkExperience.fromMap(e))
-              .toList() ??
-          [],
-      projectExperience:
-          (map['projectExperience'] as List?)
-              ?.map((e) => ProjectExperience.fromMap(e))
-              .toList() ??
-          [],
-      awards:
-          (map['awards'] as List?)?.map((e) => Award.fromMap(e)).toList() ?? [],
-      applications:
-          (map['applications'] as List?)
-              ?.map((e) => Application.fromMap(e))
-              .toList() ??
-          [],
-      notifications:
-          (map['notifications'] as List?)
-              ?.map((e) => Notification.fromMap(e))
-              .toList() ??
-          [],
+      education: education,
+      workExperience: workExperience,
+      projectExperience: projectExperience,
+      awards: awards,
+      applications: applications,
+      notifications: notifications,
     );
   }
 }

--- a/lib/screens/applicant_applications_screen.dart
+++ b/lib/screens/applicant_applications_screen.dart
@@ -1,155 +1,623 @@
 import 'package:flutter/material.dart';
+import 'package:pronto/services/application_service.dart';
+import 'package:pronto/services/job_service.dart';
+import 'package:pronto/models/application_model.dart';
+import 'package:pronto/models/job_model.dart';
+import 'package:pronto/constants/colours.dart';
+import 'package:pronto/widgets/custom_dropdown_field.dart';
+import 'package:pronto/widgets/application_card.dart';
 
-class ApplicantApplicationsScreen extends StatelessWidget {
+class ApplicantApplicationsScreen extends StatefulWidget {
   final String userId;
 
   const ApplicantApplicationsScreen({super.key, required this.userId});
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('My Applications'),
-        automaticallyImplyLeading: false,
-        backgroundColor: Theme.of(context).primaryColor,
-        foregroundColor: Colors.white,
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            // Header info
-            Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Colors.green.shade50,
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    'User ID: $userId',
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 6,
+  _ApplicantApplicationsScreenState createState() =>
+      _ApplicantApplicationsScreenState();
+}
+
+class _ApplicantApplicationsScreenState
+    extends State<ApplicantApplicationsScreen> {
+  final ApplicationService _applicationService = ApplicationService();
+  final JobService _jobService = JobService();
+  final TextEditingController _searchController = TextEditingController();
+
+  List<Application> _applications = [];
+  List<Application> _filteredApplications = [];
+  Map<String, Job> _jobsCache = {};
+  Map<String, Map<String, String?>> _companyDataCache = {};
+  bool _isLoading = true;
+
+  // Filter states
+  String? _statusFilter;
+  String? _jobTypeFilter;
+  bool? _favoriteFilter;
+  String _sortBy = 'newest'; // newest, oldest
+
+  final List<String> _statusOptions = [
+    'applied',
+    'interview',
+    'offer',
+    'rejected',
+    'withdrawn',
+  ];
+
+  final List<String> _jobTypeOptions = [
+    'Full-time',
+    'Part-time',
+    'Contract',
+    'Freelance',
+    'Internship',
+    'Temporary',
+  ];
+
+  final List<String> _sortOptions = ['newest', 'oldest'];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadApplications();
+    _searchController.addListener(_filterApplications);
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _refreshApplications() async {
+    _loadApplications();
+  }
+
+  void _loadApplications() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      Stream<List<Application>> applicationStream = _applicationService
+          .getUserApplications(widget.userId);
+
+      applicationStream.listen((applications) async {
+        // Load job data for each application
+        for (var application in applications) {
+          if (!_jobsCache.containsKey(application.jobID)) {
+            try {
+              Job? job = await _jobService.getJobById(application.jobID);
+              if (job != null) {
+                _jobsCache[application.jobID] = job;
+
+                // Get company data
+                final companyData = await _jobService.getCompanyInfoFromJob(
+                  job,
+                );
+                if (companyData != null) {
+                  _companyDataCache[application.jobID] = {
+                    'company': companyData['name'],
+                    'companyLogoUrl': companyData['logoUrl'],
+                  };
+                }
+              }
+            } catch (e) {
+              print('Error loading job ${application.jobID}: $e');
+            }
+          }
+        }
+
+        if (mounted) {
+          setState(() {
+            _applications = applications;
+            _isLoading = false;
+          });
+          _filterApplications();
+        }
+      });
+    } catch (e) {
+      print('Error loading applications: $e');
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  void _filterApplications() {
+    List<Application> filtered = List.from(_applications);
+
+    // Search filter
+    String searchQuery = _searchController.text.toLowerCase();
+    if (searchQuery.isNotEmpty) {
+      filtered = filtered.where((app) {
+        Job? job = _jobsCache[app.jobID];
+        String? company = _companyDataCache[app.jobID]?['company'];
+
+        return (job?.title.toLowerCase().contains(searchQuery) ?? false) ||
+            (company?.toLowerCase().contains(searchQuery) ?? false) ||
+            (job?.location.toLowerCase().contains(searchQuery) ?? false);
+      }).toList();
+    }
+
+    // Status filter
+    if (_statusFilter != null && _statusFilter!.isNotEmpty) {
+      filtered = filtered
+          .where(
+            (app) => app.status.toLowerCase() == _statusFilter!.toLowerCase(),
+          )
+          .toList();
+    }
+
+    // Job type filter
+    if (_jobTypeFilter != null && _jobTypeFilter!.isNotEmpty) {
+      filtered = filtered.where((app) {
+        Job? job = _jobsCache[app.jobID];
+        return job?.jobType.toLowerCase() == _jobTypeFilter!.toLowerCase();
+      }).toList();
+    }
+
+    // Favorite filter
+    if (_favoriteFilter != null) {
+      filtered = filtered
+          .where((app) => app.favorite == _favoriteFilter)
+          .toList();
+    }
+
+    // Sort by date applied
+    if (_sortBy == 'newest') {
+      filtered.sort((a, b) => b.appliedAt.compareTo(a.appliedAt));
+    } else {
+      filtered.sort((a, b) => a.appliedAt.compareTo(b.appliedAt));
+    }
+
+    setState(() {
+      _filteredApplications = filtered;
+    });
+  }
+
+  void _showFilterSheet() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setSheetState) => Container(
+          decoration: const BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text(
+                      'Filter Applications',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
-                    decoration: BoxDecoration(
-                      color: Colors.green,
-                      borderRadius: BorderRadius.circular(20),
+                    TextButton(
+                      onPressed: () {
+                        setSheetState(() {
+                          _statusFilter = null;
+                          _jobTypeFilter = null;
+                          _favoriteFilter = null;
+                          _sortBy = 'newest';
+                        });
+                        setState(() {
+                          _statusFilter = null;
+                          _jobTypeFilter = null;
+                          _favoriteFilter = null;
+                          _sortBy = 'newest';
+                        });
+                        _filterApplications();
+                      },
+                      child: const Text('Clear All'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+
+                // Status Filter Dropdown
+                CustomDropdownField(
+                  label: 'Status',
+                  value: _statusFilter,
+                  options: _statusOptions,
+                  onChanged: (value) {
+                    setSheetState(() {
+                      _statusFilter = value;
+                    });
+                  },
+                ),
+                const SizedBox(height: 16),
+
+                // Job Type Filter Dropdown
+                CustomDropdownField(
+                  label: 'Job Type',
+                  value: _jobTypeFilter,
+                  options: _jobTypeOptions,
+                  onChanged: (value) {
+                    setSheetState(() {
+                      _jobTypeFilter = value;
+                    });
+                  },
+                ),
+                const SizedBox(height: 16),
+
+                // Favorites Filter Dropdown
+                CustomDropdownField(
+                  label: 'Favorites',
+                  value: _favoriteFilter == null
+                      ? 'all'
+                      : _favoriteFilter!
+                      ? 'favorites'
+                      : 'all', // You only support true or null in your current logic
+                  options: ['all', 'favorites'],
+                  hint: 'Select Favorite Filter',
+                  onChanged: (value) {
+                    setSheetState(() {
+                      _favoriteFilter = value == 'favorites' ? true : null;
+                    });
+                  },
+                ),
+
+                const SizedBox(height: 16),
+
+                // Sort By Dropdown
+                CustomDropdownField(
+                  label: 'Sort By Date Applied',
+                  value: _sortBy,
+                  options: _sortOptions,
+                  onChanged: (value) {
+                    setSheetState(() {
+                      _sortBy = value ?? 'newest';
+                    });
+                  },
+                ),
+
+                const SizedBox(height: 24),
+
+                // Apply Button
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      setState(() {
+                        // Apply the filter states from the sheet to the main widget
+                      });
+                      _filterApplications();
+                      Navigator.pop(context);
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
                     ),
                     child: const Text(
-                      '5 Active',
-                      style: TextStyle(color: Colors.white, fontSize: 12),
+                      'Apply Filters',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _toggleFavorite(Application application) async {
+    try {
+      await _applicationService.updateApplicationFavorite(
+        widget.userId,
+        application.applicationID,
+        !application.favorite,
+      );
+    } catch (e) {
+      print('Error toggling favorite: $e');
+    }
+  }
+
+  void _updateApplicationStatus(
+    Application application,
+    String newStatus,
+  ) async {
+    try {
+      await _applicationService.updateApplicationStatus(
+        widget.userId,
+        application.applicationID,
+        newStatus,
+      );
+    } catch (e) {
+      print('Error updating status: $e');
+    }
+  }
+
+  Future<void> _deleteApplication(Application application) async {
+    try {
+      await _applicationService.deleteApplication(
+        widget.userId,
+        application.applicationID,
+      );
+
+      // Show success snackbar
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Application deleted successfully'),
+            backgroundColor: Colors.green,
+          ),
+        );
+      }
+    } catch (e) {
+      print('Error deleting application: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error deleting application: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  void _showDeleteOption(
+    BuildContext context,
+    Application application,
+    Job? job,
+    Map<String, String?>? companyData,
+  ) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (context) => Container(
+        padding: const EdgeInsets.all(24),
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Delete application for "${job?.title ?? 'Unknown Position'}" at ${companyData?['company'] ?? 'Unknown Company'}?',
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Cancel'),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      _deleteApplication(application);
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red,
+                      foregroundColor: Colors.white,
+                    ),
+                    child: const Text('Delete'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _getTimeAgo(DateTime dateTime) {
+    final now = DateTime.now();
+    final difference = now.difference(dateTime);
+
+    if (difference.inDays > 0) {
+      return '${difference.inDays}d ago';
+    } else if (difference.inHours > 0) {
+      return '${difference.inHours}h ago';
+    } else {
+      return '${difference.inMinutes}m ago';
+    }
+  }
+
+  Color _getStatusColor(String status) {
+    switch (status.toLowerCase()) {
+      case 'applied':
+        return Colors.blue;
+      case 'interview':
+        return Colors.orange;
+      case 'offer':
+        return Colors.green;
+      case 'rejected':
+        return Colors.red;
+      case 'withdrawn':
+        return Colors.grey;
+      default:
+        return Colors.blue;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Search and Filter Bar
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(25),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.grey.withOpacity(0.1),
+                            spreadRadius: 1,
+                            blurRadius: 4,
+                            offset: const Offset(0, 2),
+                          ),
+                        ],
+                      ),
+                      child: TextField(
+                        controller: _searchController,
+                        decoration: InputDecoration(
+                          hintText: 'Search applications...',
+                          hintStyle: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                          prefixIcon: Icon(
+                            Icons.search,
+                            color: Colors.grey[400],
+                            size: 20,
+                          ),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(
+                              25,
+                            ), // More rounded
+                            borderSide: BorderSide.none,
+                          ),
+                          filled: true,
+                          fillColor: Colors.white,
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 20,
+                            vertical: 12,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  // Filter button
+                  GestureDetector(
+                    onTap: _showFilterSheet,
+                    child: Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: Colors.transparent,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Icon(
+                        Icons.tune,
+                        color: Colors.grey[700],
+                        size: 24,
+                      ),
                     ),
                   ),
                 ],
               ),
             ),
-            const SizedBox(height: 20),
 
-            // Applications list
+            // Applications List with RefreshIndicator
             Expanded(
-              child: ListView.builder(
-                itemCount: 7,
-                itemBuilder: (context, index) {
-                  final companies = [
-                    'Google',
-                    'Apple',
-                    'Microsoft',
-                    'Meta',
-                    'Netflix',
-                    'Amazon',
-                    'Tesla',
-                  ];
-                  final positions = [
-                    'Software Engineer',
-                    'Product Manager',
-                    'UI/UX Designer',
-                    'Data Scientist',
-                    'DevOps Engineer',
-                    'Frontend Developer',
-                    'Backend Developer',
-                  ];
-                  final statuses = [
-                    'Under Review',
-                    'Interview Scheduled',
-                    'Pending',
-                    'Shortlisted',
-                    'Rejected',
-                    'Accepted',
-                    'Applied',
-                  ];
-                  final statusColors = [
-                    Colors.orange,
-                    Colors.blue,
-                    Colors.grey,
-                    Colors.purple,
-                    Colors.red,
-                    Colors.green,
-                    Colors.teal,
-                  ];
-
-                  return Card(
-                    margin: const EdgeInsets.only(bottom: 12),
-                    elevation: 2,
-                    child: ListTile(
-                      contentPadding: const EdgeInsets.all(16),
-                      leading: CircleAvatar(
-                        backgroundColor: statusColors[index],
-                        child: Text(
-                          companies[index][0],
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                      title: Text(
-                        positions[index],
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                      subtitle: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(companies[index]),
-                          const SizedBox(height: 4),
-                          Text(
-                            'Applied ${index + 1} days ago',
-                            style: const TextStyle(
-                              fontSize: 12,
-                              color: Colors.grey,
+              child: RefreshIndicator(
+                onRefresh: _refreshApplications,
+                // Custom refresh indicator styling (not working rn)
+                color: AppColors.primary,
+                backgroundColor: Colors.white,
+                displacement: 40,
+                strokeWidth: 2.5,
+                child: _isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : _filteredApplications.isEmpty
+                    ? SingleChildScrollView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        child: Container(
+                          height: MediaQuery.of(context).size.height * 0.6,
+                          child: Center(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Icon(
+                                  Icons.assignment_outlined,
+                                  size: 64,
+                                  color: Colors.grey[400],
+                                ),
+                                const SizedBox(height: 16),
+                                Text(
+                                  'No applications found',
+                                  style: TextStyle(
+                                    fontSize: 18,
+                                    color: Colors.grey[600],
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Text(
+                                  'Try adjusting your search or filters',
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    color: Colors.grey[500],
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
-                        ],
+                        ),
+                      )
+                    : ListView.builder(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        itemCount: _filteredApplications.length,
+                        itemBuilder: (context, index) {
+                          final application = _filteredApplications[index];
+                          final job = _jobsCache[application.jobID];
+                          final companyData =
+                              _companyDataCache[application.jobID];
+
+                          return ApplicationCard(
+                            application: application,
+                            job: job,
+                            companyData: companyData,
+                            statusOptions: _statusOptions,
+                            onDelete: () => _showDeleteOption(
+                              context,
+                              application,
+                              job,
+                              companyData,
+                            ),
+                            onToggleFavorite: () =>
+                                _toggleFavorite(application),
+                            onUpdateStatus: (newStatus) =>
+                                _updateApplicationStatus(
+                                  application,
+                                  newStatus,
+                                ),
+                            timeAgo: _getTimeAgo(application.appliedAt),
+                            getStatusColor: _getStatusColor,
+                          );
+                        },
                       ),
-                      trailing: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 6,
-                        ),
-                        decoration: BoxDecoration(
-                          color: statusColors[index].withOpacity(0.1),
-                          borderRadius: BorderRadius.circular(20),
-                          border: Border.all(
-                            color: statusColors[index].withOpacity(0.3),
-                          ),
-                        ),
-                        child: Text(
-                          statuses[index],
-                          style: TextStyle(
-                            color: statusColors[index],
-                            fontWeight: FontWeight.bold,
-                            fontSize: 12,
-                          ),
-                        ),
-                      ),
-                    ),
-                  );
-                },
               ),
             ),
           ],

--- a/lib/screens/applicant_home_screen.dart
+++ b/lib/screens/applicant_home_screen.dart
@@ -349,7 +349,6 @@ class _ApplicantHomeScreenState extends State<ApplicantHomeScreen> {
                       onPressed: _navigateToFilters,
                       icon: const Icon(Icons.tune),
                       style: IconButton.styleFrom(
-                        backgroundColor: Colors.white,
                         foregroundColor: Colors.grey[700],
                       ),
                     ),

--- a/lib/services/application_service.dart
+++ b/lib/services/application_service.dart
@@ -1,0 +1,196 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:pronto/models/application_model.dart';
+
+class ApplicationService {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  // Get all applications (from subcollection) of a user
+  Stream<List<Application>> getUserApplications(String userId) {
+    return _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('applications')
+        .snapshots()
+        .map((snapshot) {
+          return snapshot.docs.map((doc) {
+            return Application.fromMap(doc.data(), doc.id);
+          }).toList();
+        });
+  }
+
+  // Get a specific application by ID
+  Future<Application?> getApplicationById(
+    String userId,
+    String applicationId,
+  ) async {
+    try {
+      final doc = await _firestore
+          .collection('users')
+          .doc(userId)
+          .collection('applications')
+          .doc(applicationId)
+          .get();
+
+      if (doc.exists) {
+        return Application.fromMap(doc.data()!, doc.id);
+      }
+      return null;
+    } catch (e) {
+      print('Error getting application: $e');
+      return null;
+    }
+  }
+
+  // Create a new application
+  Future<String> createApplication({
+    required String userId,
+    required String jobId,
+    String? resumeUrl,
+  }) async {
+    try {
+      final applicationRef = await _firestore
+          .collection('users')
+          .doc(userId)
+          .collection('applications')
+          .add({
+            'jobId': jobId,
+            'status': 'applied',
+            'appliedAt': FieldValue.serverTimestamp(),
+            'resumeUrl': resumeUrl,
+            'favorite': false,
+          });
+
+      return applicationRef.id;
+    } catch (e) {
+      print('Error creating application: $e');
+      throw e;
+    }
+  }
+
+  // Update application status
+  Future<void> updateApplicationStatus(
+    String userId,
+    String applicationId,
+    String newStatus,
+  ) async {
+    try {
+      await _firestore
+          .collection('users')
+          .doc(userId)
+          .collection('applications')
+          .doc(applicationId)
+          .update({'status': newStatus});
+    } catch (e) {
+      print('Error updating application status: $e');
+      throw e;
+    }
+  }
+
+  // Update application favorite
+  Future<void> updateApplicationFavorite(
+    String userId,
+    String applicationId,
+    bool favorite,
+  ) async {
+    try {
+      await _firestore
+          .collection('users')
+          .doc(userId)
+          .collection('applications')
+          .doc(applicationId)
+          .update({'favorite': favorite});
+    } catch (e) {
+      print('Error updating application favorite: $e');
+      throw e;
+    }
+  }
+
+  // Delete an application
+  Future<void> deleteApplication(String userId, String applicationId) async {
+    try {
+      final application = await getApplicationById(userId, applicationId);
+      if (application == null) {
+        throw Exception('Application not found');
+      }
+
+      final jobId = application.jobID;
+
+      final jobRef = _firestore.collection('jobs').doc(jobId);
+      final appRef = _firestore
+          .collection('users')
+          .doc(userId)
+          .collection('applications')
+          .doc(applicationId);
+
+      final batch = _firestore.batch();
+
+      batch.update(jobRef, {
+        'usersApplied': FieldValue.arrayRemove([userId]),
+        'usersDeclined': FieldValue.arrayUnion([userId]),
+      });
+
+      batch.delete(appRef);
+
+      await batch.commit();
+    } catch (e) {
+      print('Error deleting application: $e');
+      throw e;
+    }
+  }
+
+  // Get applications filtered by status
+  Stream<List<Application>> getApplicationsByStatus(
+    String userId,
+    String status,
+  ) {
+    return _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('applications')
+        .where('status', isEqualTo: status)
+        .snapshots()
+        .map((snapshot) {
+          return snapshot.docs.map((doc) {
+            return Application.fromMap(doc.data(), doc.id);
+          }).toList();
+        });
+  }
+
+  // Get favorite applications
+  Stream<List<Application>> getFavoriteApplications(String userId) {
+    return _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('applications')
+        .where('favorite', isEqualTo: true)
+        .snapshots()
+        .map((snapshot) {
+          return snapshot.docs.map((doc) {
+            return Application.fromMap(doc.data(), doc.id);
+          }).toList();
+        });
+  }
+
+  // Get applications count by status
+  Future<Map<String, int>> getApplicationsCountByStatus(String userId) async {
+    try {
+      final snapshot = await _firestore
+          .collection('users')
+          .doc(userId)
+          .collection('applications')
+          .get();
+
+      Map<String, int> statusCounts = {};
+
+      for (final doc in snapshot.docs) {
+        final status = doc.data()['status'] ?? 'applied';
+        statusCounts[status] = (statusCounts[status] ?? 0) + 1;
+      }
+
+      return statusCounts;
+    } catch (e) {
+      print('Error getting applications count: $e');
+      return {};
+    }
+  }
+}

--- a/lib/widgets/application_card.dart
+++ b/lib/widgets/application_card.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:pronto/models/application_model.dart';
+import 'package:pronto/models/job_model.dart';
+import 'package:pronto/constants/colours.dart';
+import 'package:pronto/router.dart';
+
+class ApplicationCard extends StatelessWidget {
+  final Application application;
+  final Job? job;
+  final Map<String, String?>? companyData;
+  final List<String> statusOptions;
+  final void Function() onDelete;
+  final void Function() onToggleFavorite;
+  final void Function(String newStatus) onUpdateStatus;
+  final String timeAgo;
+  final Color Function(String status) getStatusColor;
+
+  const ApplicationCard({
+    super.key,
+    required this.application,
+    required this.job,
+    required this.companyData,
+    required this.statusOptions,
+    required this.onDelete,
+    required this.onToggleFavorite,
+    required this.onUpdateStatus,
+    required this.timeAgo,
+    required this.getStatusColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Slidable(
+        key: Key(application.applicationID),
+        endActionPane: ActionPane(
+          motion: const DrawerMotion(),
+          extentRatio: 0.25,
+          children: [
+            SlidableAction(
+              onPressed: (context) => onDelete(),
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+              icon: Icons.delete,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(0),
+                bottomLeft: Radius.circular(0),
+                topRight: Radius.circular(12),
+                bottomRight: Radius.circular(12),
+              ),
+            ),
+          ],
+        ),
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.grey.withOpacity(0.1),
+                spreadRadius: 1,
+                blurRadius: 4,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: InkWell(
+            onTap: job != null
+                ? () => NavigationHelper.navigateTo(
+                    '/job-details',
+                    arguments: job,
+                  )
+                : null,
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(12),
+              bottomLeft: Radius.circular(12),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Company Logo
+                  Container(
+                    width: 60,
+                    height: 60,
+                    decoration: BoxDecoration(
+                      color: Colors.grey[100],
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: companyData?['companyLogoUrl'] != null
+                        ? ClipRRect(
+                            borderRadius: BorderRadius.circular(10),
+                            child: Image.network(
+                              companyData!['companyLogoUrl']!,
+                              fit: BoxFit.cover,
+                              errorBuilder: (context, error, stackTrace) =>
+                                  Icon(
+                                    Icons.business,
+                                    color: Colors.grey[400],
+                                    size: 28,
+                                  ),
+                            ),
+                          )
+                        : Icon(
+                            Icons.business,
+                            color: Colors.grey[400],
+                            size: 28,
+                          ),
+                  ),
+                  const SizedBox(width: 12),
+
+                  // Job Info
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Top row
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Expanded(
+                              child: Text(
+                                '${companyData?['company'] ?? 'Unknown Company'} • ${job?.location ?? 'Unknown'} (${job?.workArrangement ?? 'Unknown'})',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: Colors.grey[600],
+                                  fontWeight: FontWeight.w500,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            GestureDetector(
+                              onTap: onToggleFavorite,
+                              child: Icon(
+                                application.favorite
+                                    ? Icons.bookmark
+                                    : Icons.bookmark_border,
+                                color: application.favorite
+                                    ? AppColors.primary
+                                    : Colors.grey,
+                                size: 20,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+
+                        // Job Title
+                        Text(
+                          job?.title ?? 'Unknown Position',
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 12),
+
+                        // Bottom row: status and time
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: getStatusColor(
+                                  application.status,
+                                ).withOpacity(0.1),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: getStatusColor(
+                                    application.status,
+                                  ).withOpacity(0.3),
+                                ),
+                              ),
+                              child: DropdownButton<String>(
+                                value: application.status,
+                                isDense: true,
+                                underline: const SizedBox(),
+                                style: TextStyle(
+                                  fontSize: 11,
+                                  color: getStatusColor(application.status),
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                items: statusOptions
+                                    .map(
+                                      (status) => DropdownMenuItem(
+                                        value: status,
+                                        child: Text(status),
+                                      ),
+                                    )
+                                    .toList(),
+                                onChanged: (newStatus) {
+                                  if (newStatus != null)
+                                    onUpdateStatus(newStatus);
+                                },
+                              ),
+                            ),
+                            Text(
+                              timeAgo,
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: Colors.grey[500],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Added getJobById function to job_service.dart
- Created application_card in widgets folder and imported it for use in applications screen
- Fetch all applications (according to filter) and load them accordingly
- Able to search application by job title, company, location
- Able to filter by status, job type, favourites, and sort by date applied
- Able to favourite an application
- Able to change status of application e.g. applied, interview, etc.
- Able to swipe left to delete (used batch write so both actions succeed or fail together)
- Able to pull down to refresh (not working - could be because it’s a stream?)

Applicant Home Page:
- Got rid of the white background in the filter icon

In the future:
- Somehow link status of job for applicant to recruiter such that when recruiter updates on their end, it is also reflected for the user (?)