### PR TITLE
Applicant Notifications Page: fetch, display and logic

### DIFF
--- a/lib/models/notification_model.dart
+++ b/lib/models/notification_model.dart
@@ -1,41 +1,71 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Notification {
-  String notificationID;
-  String applicationID;
-  String type;
-  String message;
-  bool read;
-  DateTime timeStamp;
+  final String notificationID;
+  final String applicationID;
+  final String type;
+  final bool read;
+  final DateTime timeStamp;
+  final String? jobID;
+  final String? jobTitle;
+  final String? companyName;
 
   Notification({
     required this.notificationID,
     required this.applicationID,
     required this.type,
-    required this.message,
     required this.read,
     required this.timeStamp,
+    this.jobID,
+    this.jobTitle,
+    this.companyName,
   });
+
+  factory Notification.fromMap(Map<String, dynamic> data, String id) {
+    return Notification(
+      notificationID: id,
+      applicationID: data['applicationId'] ?? '',
+      type: data['type'] ?? '',
+      read: data['read'] ?? false,
+      timeStamp: (data['timeStamp'] as Timestamp).toDate(),
+      jobID: data['jobId'],
+      jobTitle: data['jobTitle'],
+      companyName: data['companyName'],
+    );
+  }
 
   Map<String, dynamic> toMap() {
     return {
-      'notificationID': notificationID,
-      'applicationID': applicationID,
+      'applicationId': applicationID,
       'type': type,
-      'message': message,
       'read': read,
       'timeStamp': Timestamp.fromDate(timeStamp),
+      if (jobID != null) 'jobId': jobID,
+      if (jobTitle != null) 'jobTitle': jobTitle,
+      if (companyName != null) 'companyName': companyName,
     };
   }
 
-  factory Notification.fromMap(Map<String, dynamic> map) {
+  Notification copyWith({
+    String? notificationID,
+    String? applicationID,
+    String? type,
+    String? message,
+    bool? read,
+    DateTime? timeStamp,
+    String? jobID,
+    String? jobTitle,
+    String? companyName,
+  }) {
     return Notification(
-      notificationID: map['notificationID'] ?? '',
-      applicationID: map['applicationID'] ?? '',
-      type: map['type'] ?? '',
-      message: map['message'] ?? '',
-      read: map['read'] ?? false,
-      timeStamp: (map['timeStamp'] as Timestamp).toDate(),
+      notificationID: notificationID ?? this.notificationID,
+      applicationID: applicationID ?? this.applicationID,
+      type: type ?? this.type,
+      read: read ?? this.read,
+      timeStamp: timeStamp ?? this.timeStamp,
+      jobID: jobID ?? this.jobID,
+      jobTitle: jobTitle ?? this.jobTitle,
+      companyName: companyName ?? this.companyName,
     );
   }
 }

--- a/lib/screens/notifications_screen.dart
+++ b/lib/screens/notifications_screen.dart
@@ -1,194 +1,298 @@
 import 'package:flutter/material.dart';
+import 'package:pronto/services/notification_service.dart';
+import 'package:pronto/services/job_service.dart';
+import 'package:pronto/models/notification_model.dart' as pronto;
+import 'package:pronto/widgets/notification_card.dart';
+import 'package:pronto/router.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
-class NotificationsScreen extends StatelessWidget {
+class NotificationsScreen extends StatefulWidget {
   final String userId;
 
-  const NotificationsScreen({Key? key, required this.userId}) : super(key: key);
+  const NotificationsScreen({super.key, required this.userId});
+
+  @override
+  _NotificationsScreenState createState() => _NotificationsScreenState();
+}
+
+class _NotificationsScreenState extends State<NotificationsScreen> {
+  final NotificationService _notificationService = NotificationService();
+  final JobService _jobService = JobService();
+  final TextEditingController _searchController = TextEditingController();
+  final Set<String> _viewedNotifications =
+      <String>{}; // Track viewed notifications
+
+  bool _isLoading = true;
+  List<pronto.Notification> _notifications = [];
+  List<pronto.Notification> _filteredNotifications = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadNotifications();
+    _markAllAsReadAfterDelay();
+    _searchController.addListener(_filterNotifications);
+  }
+
+  // Mark all notifications as read after a short delay when user opens the page
+  void _markAllAsReadAfterDelay() {
+    Future.delayed(const Duration(milliseconds: 1500), () {
+      if (mounted) {
+        _notificationService.markAllNotificationsAsRead(widget.userId);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _loadNotifications() {
+    _notificationService
+        .getNotifications(widget.userId)
+        .listen(
+          (notifications) {
+            if (mounted) {
+              setState(() {
+                _notifications = notifications;
+                _filteredNotifications = notifications;
+                _isLoading = false;
+              });
+              // Run after the first frame to ensure visibility detection works (ts not working bruh)
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                for (var n in notifications) {
+                  if (!n.read) {
+                    _markNotificationAsRead(n);
+                  }
+                }
+              });
+            }
+          },
+          onError: (error) {
+            print('Error loading notifications: $error');
+            if (mounted) {
+              setState(() {
+                _isLoading = false;
+              });
+            }
+          },
+        );
+  }
+
+  void _filterNotifications() {
+    String searchQuery = _searchController.text.toLowerCase();
+
+    setState(() {
+      if (searchQuery.isEmpty) {
+        _filteredNotifications = _notifications;
+      } else {
+        _filteredNotifications = _notifications.where((notification) {
+          return (notification.jobTitle?.toLowerCase().contains(searchQuery) ??
+                  false) ||
+              (notification.companyName?.toLowerCase().contains(searchQuery) ??
+                  false) ||
+              (notification.type.toLowerCase().contains(searchQuery));
+        }).toList();
+      }
+    });
+  }
+
+  // Mark notification as read when it becomes visible
+  void _markNotificationAsRead(pronto.Notification notification) {
+    // Only mark as read if it hasn't been read yet and we haven't already processed it
+    if (!notification.read &&
+        !_viewedNotifications.contains(notification.notificationID)) {
+      _viewedNotifications.add(notification.notificationID);
+
+      // Update the notification service
+      _notificationService
+          .markNotificationAsRead(widget.userId, notification.notificationID)
+          .catchError((error) {
+            print('Error marking notification as read: $error');
+            // Remove from viewed set if update failed
+            _viewedNotifications.remove(notification.notificationID);
+          });
+    }
+  }
+
+  void _handleNotificationTap(pronto.Notification notification) async {
+    // Mark as read when tapped
+    _markNotificationAsRead(notification);
+
+    // Only navigate for status update notifications with valid job IDs
+    if ((notification.type == 'interview' ||
+            notification.type == 'offer' ||
+            notification.type == 'rejected') &&
+        notification.jobID != null) {
+      try {
+        final job = await _jobService.getJobById(notification.jobID!);
+        if (job != null && mounted) {
+          NavigationHelper.navigateTo('/job-details', arguments: job);
+        } else {
+          _showJobNotFoundSnackBar();
+        }
+      } catch (e) {
+        print('Error fetching job details: $e');
+        _showJobNotFoundSnackBar();
+      }
+    }
+  }
+
+  void _showJobNotFoundSnackBar() {
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Job no longer available'),
+          backgroundColor: Colors.orange,
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
+  void _clearAllNotifications() async {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Clear All Notifications'),
+          content: const Text(
+            'Are you sure you want to delete all notifications? This action cannot be undone.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () async {
+                Navigator.of(context).pop();
+
+                // Delete all notifications
+                try {
+                  for (var notification in _notifications) {
+                    await _notificationService.deleteNotification(
+                      widget.userId,
+                      notification.notificationID,
+                    );
+                  }
+
+                  if (mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('All notifications cleared'),
+                        duration: Duration(seconds: 2),
+                      ),
+                    );
+                  }
+                } catch (e) {
+                  print('Error clearing notifications: $e');
+                  if (mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Failed to clear notifications'),
+                        backgroundColor: Colors.red,
+                        duration: Duration(seconds: 2),
+                      ),
+                    );
+                  }
+                }
+              },
+              child: const Text(
+                'Clear All',
+                style: TextStyle(color: Colors.red),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    // Move this list outside itemBuilder
-    final notifications = [
-      {
-        'title': 'New job match found!',
-        'subtitle': 'Software Engineer position at Google matches your profile',
-        'time': '5m ago',
-        'isNew': true,
-      },
-      {
-        'title': 'Application status update',
-        'subtitle': 'Your application for Product Manager role was reviewed',
-        'time': '1h ago',
-        'isNew': true,
-      },
-      {
-        'title': 'Interview invitation',
-        'subtitle': 'You\'ve been invited for an interview on Monday at 2 PM',
-        'time': '2h ago',
-        'isNew': true,
-      },
-      {
-        'title': 'Profile view',
-        'subtitle': 'A recruiter viewed your profile',
-        'time': '4h ago',
-        'isNew': false,
-      },
-      {
-        'title': 'Job recommendation',
-        'subtitle': '5 new jobs match your skills and preferences',
-        'time': '6h ago',
-        'isNew': false,
-      },
-      {
-        'title': 'Application reminder',
-        'subtitle':
-            'Don\'t forget to complete your application for UI/UX Designer',
-        'time': '1d ago',
-        'isNew': false,
-      },
-      {
-        'title': 'Skills assessment',
-        'subtitle':
-            'Complete your Flutter skills assessment to boost your profile',
-        'time': '2d ago',
-        'isNew': false,
-      },
-      {
-        'title': 'Weekly job digest',
-        'subtitle': '15 new jobs posted in your area this week',
-        'time': '3d ago',
-        'isNew': false,
-      },
-    ];
-
-    final newCount = notifications.where((n) => n['isNew'] == true).length;
-
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Notifications'),
-        automaticallyImplyLeading: false,
-        backgroundColor: Theme.of(context).primaryColor,
-        foregroundColor: Colors.white,
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.mark_email_read),
-            onPressed: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('All notifications marked as read'),
-                ),
-              );
-              // If needed, implement mark-as-read logic here
-            },
-          ),
-        ],
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
+      backgroundColor: Colors.grey[50],
+      body: SafeArea(
         child: Column(
           children: [
-            // Header
-            Container(
+            // Search and Clear All Bar
+            Padding(
               padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Colors.red.shade50,
-                borderRadius: BorderRadius.circular(12),
-              ),
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(
-                    'User ID: $userId',
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  if (newCount > 0)
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 6,
-                      ),
+                  Expanded(
+                    child: Container(
                       decoration: BoxDecoration(
-                        color: Colors.red,
-                        borderRadius: BorderRadius.circular(20),
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(25),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.grey.withOpacity(0.1),
+                            spreadRadius: 1,
+                            blurRadius: 4,
+                            offset: const Offset(0, 2),
+                          ),
+                        ],
                       ),
-                      child: Text(
-                        '$newCount New',
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 12,
+                      child: TextField(
+                        controller: _searchController,
+                        decoration: InputDecoration(
+                          hintText: 'Search notifications...',
+                          hintStyle: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                          prefixIcon: Icon(
+                            Icons.search,
+                            color: Colors.grey[400],
+                            size: 20,
+                          ),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(25),
+                            borderSide: BorderSide.none,
+                          ),
+                          filled: true,
+                          fillColor: Colors.white,
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 20,
+                            vertical: 12,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  // Clear All icon button
+                  if (_notifications.isNotEmpty)
+                    GestureDetector(
+                      onTap: _clearAllNotifications,
+                      child: Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Colors.transparent,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Icon(
+                          Icons.delete_sweep_rounded,
+                          color: Colors.grey[700],
+                          size: 24,
                         ),
                       ),
                     ),
                 ],
               ),
             ),
-            const SizedBox(height: 20),
 
-            // Notification List
+            // Notifications List
             Expanded(
-              child: ListView.builder(
-                itemCount: notifications.length,
-                itemBuilder: (context, index) {
-                  final notification = notifications[index];
-                  final isNew = notification['isNew'] as bool;
-
-                  return Card(
-                    margin: const EdgeInsets.only(bottom: 8),
-                    elevation: isNew ? 3 : 1,
-                    color: isNew ? Colors.blue.shade50 : null,
-                    child: ListTile(
-                      leading: CircleAvatar(
-                        backgroundColor: isNew
-                            ? Colors.blue
-                            : Colors.grey.shade300,
-                        child: Icon(
-                          _getNotificationIcon(index),
-                          color: isNew ? Colors.white : Colors.grey.shade600,
-                          size: 20,
-                        ),
-                      ),
-                      title: Text(
-                        notification['title'] as String,
-                        style: TextStyle(
-                          fontWeight: isNew
-                              ? FontWeight.bold
-                              : FontWeight.normal,
-                        ),
-                      ),
-                      subtitle: Text(
-                        notification['subtitle'] as String,
-                        style: TextStyle(
-                          fontSize: 13,
-                          color: Colors.grey.shade600,
-                        ),
-                      ),
-                      trailing: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            notification['time'] as String,
-                            style: TextStyle(
-                              fontSize: 11,
-                              color: Colors.grey.shade500,
-                            ),
-                          ),
-                          if (isNew) ...[
-                            const SizedBox(height: 4),
-                            Container(
-                              width: 8,
-                              height: 8,
-                              decoration: const BoxDecoration(
-                                color: Colors.blue,
-                                shape: BoxShape.circle,
-                              ),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
-                  );
-                },
-              ),
+              child: _isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : _filteredNotifications.isEmpty
+                  ? _buildEmptyState()
+                  : _buildNotificationsList(),
             ),
           ],
         ),
@@ -196,17 +300,63 @@ class NotificationsScreen extends StatelessWidget {
     );
   }
 
-  IconData _getNotificationIcon(int index) {
-    final icons = [
-      Icons.work,
-      Icons.update,
-      Icons.calendar_today,
-      Icons.visibility,
-      Icons.recommend,
-      Icons.alarm,
-      Icons.quiz,
-      Icons.email,
-    ];
-    return icons[index % icons.length];
+  Widget _buildEmptyState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.notifications_none, size: 64, color: Colors.grey[400]),
+          const SizedBox(height: 16),
+          Text(
+            _notifications.isEmpty
+                ? 'No notifications yet'
+                : 'No notifications found',
+            style: TextStyle(
+              fontSize: 18,
+              color: Colors.grey[600],
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            _notifications.isEmpty
+                ? 'You\'ll see updates about your job applications here'
+                : 'Try adjusting your search',
+            style: TextStyle(fontSize: 14, color: Colors.grey[500]),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNotificationsList() {
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      itemCount: _filteredNotifications.length,
+      itemBuilder: (context, index) {
+        final notification = _filteredNotifications[index];
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6),
+          child: VisibilityDetector(
+            key: Key('notification_${notification.notificationID}'),
+            onVisibilityChanged: (visibilityInfo) {
+              if (visibilityInfo.visibleFraction >= 0.5) {
+                _markNotificationAsRead(notification);
+              }
+            },
+            child: NotificationCard(
+              notification: notification,
+              onTap: () => _handleNotificationTap(notification),
+              onDelete: () => NotificationService().deleteNotification(
+                widget.userId,
+                notification.notificationID,
+              ),
+            ),
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,147 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:pronto/models/notification_model.dart';
+import 'package:pronto/services/job_service.dart';
+
+class NotificationService {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  // HELPER: Determine user type
+  Future<bool> _isRecruiter(String userId) async {
+    final doc = await _firestore.collection('recruiters').doc(userId).get();
+    return doc.exists;
+  }
+
+  // Get notifications for a specific user
+  Stream<List<Notification>> getNotifications(String userId) async* {
+    final isRecruiter = await _isRecruiter(userId);
+    final collectionName = isRecruiter ? 'recruiters' : 'users';
+
+    yield* _firestore
+        .collection(collectionName)
+        .doc(userId)
+        .collection('notifications')
+        .orderBy('timeStamp', descending: true)
+        .snapshots()
+        .asyncMap((snapshot) async {
+          List<Notification> notifications = [];
+
+          for (var doc in snapshot.docs) {
+            var notification = Notification.fromMap(doc.data(), doc.id);
+
+            // If it's a status update notification, try to fetch job and company info
+            if ((notification.type == 'interview' ||
+                    notification.type == 'offer' ||
+                    notification.type == 'rejected' ||
+                    notification.type == 'status_update') &&
+                notification.jobID != null) {
+              try {
+                var job = await JobService().getJobById(notification.jobID!);
+
+                if (job != null) {
+                  String jobTitle = job.title;
+                  String companyName = 'Unknown Company';
+
+                  var recruiterDoc = await _firestore
+                      .collection('recruiters')
+                      .doc(job.recruiterId)
+                      .get();
+
+                  if (recruiterDoc.exists) {
+                    var recruiterData = recruiterDoc.data()!;
+                    String? companyId = recruiterData['companyId'];
+
+                    if (companyId != null) {
+                      var companyDoc = await _firestore
+                          .collection('companies')
+                          .doc(companyId)
+                          .get();
+
+                      if (companyDoc.exists) {
+                        companyName =
+                            companyDoc.data()?['name'] ?? 'Unknown Company';
+                      }
+                    }
+                  }
+
+                  // Update notification with job + company details
+                  notification = notification.copyWith(
+                    jobTitle: jobTitle,
+                    companyName: companyName,
+                  );
+                }
+              } catch (e) {
+                print('Error fetching job details for notification: $e');
+              }
+            }
+
+            notifications.add(notification);
+          }
+
+          return notifications;
+        });
+  }
+
+  // Mark notification as read
+  Future<void> markNotificationAsRead(
+    String userId,
+    String notificationId,
+  ) async {
+    final isRecruiter = await _isRecruiter(userId);
+    final collectionName = isRecruiter ? 'recruiters' : 'users';
+
+    try {
+      await _firestore
+          .collection(collectionName)
+          .doc(userId)
+          .collection('notifications')
+          .doc(notificationId)
+          .update({'read': true});
+    } catch (e) {
+      print('Error marking notification as read: $e');
+      throw e;
+    }
+  }
+
+  // Mark all notifications as read
+  Future<void> markAllNotificationsAsRead(String userId) async {
+    final isRecruiter = await _isRecruiter(userId);
+    final collectionName = isRecruiter ? 'recruiters' : 'users';
+
+    try {
+      var batch = _firestore.batch();
+      var notifications = await _firestore
+          .collection(collectionName)
+          .doc(userId)
+          .collection('notifications')
+          .where('read', isEqualTo: false)
+          .get();
+
+      for (var doc in notifications.docs) {
+        batch.update(doc.reference, {'read': true});
+      }
+
+      await batch.commit();
+    } catch (e) {
+      print('Error marking all notifications as read: $e');
+      throw e;
+    }
+  }
+
+  // Delete notification
+  Future<void> deleteNotification(String userId, String notificationId) async {
+    final isRecruiter = await _isRecruiter(userId);
+    final collectionName = isRecruiter ? 'recruiters' : 'users';
+
+    try {
+      await _firestore
+          .collection(collectionName)
+          .doc(userId)
+          .collection('notifications')
+          .doc(notificationId)
+          .delete();
+    } catch (e) {
+      print('Error deleting notification: $e');
+      throw e;
+    }
+  }
+}

--- a/lib/widgets/notification_card.dart
+++ b/lib/widgets/notification_card.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:pronto/models/notification_model.dart' as pronto;
+import 'package:pronto/constants/colours.dart';
+
+class NotificationCard extends StatelessWidget {
+  final pronto.Notification notification;
+  final VoidCallback? onTap;
+  final VoidCallback? onDelete;
+
+  const NotificationCard({
+    super.key,
+    required this.notification,
+    this.onTap,
+    this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Slidable(
+      key: ValueKey(notification.notificationID),
+      endActionPane: ActionPane(
+        motion: const DrawerMotion(),
+        extentRatio: 0.25,
+        children: [
+          SlidableAction(
+            onPressed: (context) => onDelete?.call(),
+            backgroundColor: Colors.red,
+            foregroundColor: Colors.white,
+            icon: Icons.delete_outline,
+            borderRadius: const BorderRadius.only(
+              topRight: Radius.circular(12),
+              bottomRight: Radius.circular(12),
+            ),
+          ),
+        ],
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          color: notification.read ? Colors.white : Colors.blue.shade50,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.grey.withOpacity(0.1),
+              spreadRadius: 1,
+              blurRadius: 3,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                // Icon section (left)
+                Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: _getIconBackgroundColor().withOpacity(0.1),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: Icon(
+                      _getNotificationIcon(),
+                      color: _getIconBackgroundColor(),
+                      size: 20,
+                    ),
+                  ),
+                ),
+
+                const SizedBox(width: 16),
+
+                // Notification content
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (notification.jobTitle != null &&
+                          notification.companyName != null)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 4),
+                          child: Text(
+                            '${notification.jobTitle} at ${notification.companyName}',
+                            style: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                              color: Colors.black87,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              getNotificationText(),
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: Colors.grey[700],
+                                fontWeight: notification.read
+                                    ? FontWeight.normal
+                                    : FontWeight.w500,
+                              ),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          // Timestamp
+                          Text(
+                            _formatTimeAgo(notification.timeStamp),
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.grey[500],
+                              fontWeight: FontWeight.w400,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconData _getNotificationIcon() {
+    switch (notification.type) {
+      case 'interview':
+        return Icons.event_available_outlined;
+      case 'offer':
+        return Icons.check_circle_outline;
+      case 'rejected':
+        return Icons.cancel_outlined;
+      case 'job_closed':
+        return Icons.lock_outline;
+      default:
+        return Icons.notifications_outlined;
+    }
+  }
+
+  Color _getIconBackgroundColor() {
+    switch (notification.type) {
+      case 'interview':
+        return AppColors.primary;
+      case 'offer':
+        return Colors.green;
+      case 'rejected':
+        return Colors.red;
+      case 'job_closed':
+        return Colors.orange;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  String getNotificationText() {
+    switch (notification.type) {
+      case 'interview':
+        return 'You have a new interview scheduled. Check your emails for details.';
+      case 'offer':
+        return 'Congratulations! You have received a job offer. Check your emails for details.';
+      case 'rejected':
+        return 'Your application has been rejected. Check your emails for details.';
+      case 'job_closed':
+        return 'The job you applied for has been closed';
+      default:
+        return 'You have a new notification';
+    }
+  }
+
+  String _formatTimeAgo(DateTime dateTime) {
+    final now = DateTime.now();
+    final difference = now.difference(dateTime);
+
+    if (difference.inMinutes < 1) {
+      return 'Just now';
+    } else if (difference.inMinutes < 60) {
+      return '${difference.inMinutes}m ago';
+    } else if (difference.inHours < 24) {
+      return '${difference.inHours}h ago';
+    } else if (difference.inDays < 7) {
+      return '${difference.inDays}d ago';
+    } else if (difference.inDays < 30) {
+      final weeks = (difference.inDays / 7).floor();
+      return '${weeks}w ago';
+    } else if (difference.inDays < 365) {
+      final months = (difference.inDays / 30).floor();
+      return '${months}mo ago';
+    } else {
+      final years = (difference.inDays / 365).floor();
+      return '${years}y ago';
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -597,6 +597,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  visibility_detector:
+    dependency: "direct main"
+    description:
+      name: visibility_detector
+      sha256: dd5cc11e13494f432d15939c3aa8ae76844c42b723398643ce9addb88a5ed420
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0+2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   flutter_slidable: ^4.0.0
   url_launcher: ^6.2.5
   flutter_card_swiper: ^7.0.2
+  visibility_detector: ^0.4.0+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Fetches and displays notifications from notifications sub collection of a applicant (includes icons and timestamps)
- Unread notifications are highlighted in light blue; read notifications are shown on a white background
- Mark notification as read when applicant has seen the page
- 2 types of notifications: status updates (interview, offer, rejected) and job close
    - Job status updates: A notification is sent when a recruiter updates an applicant’s status (e.g., applied → interview / offer / rejected) in the application. This also includes updating the job document (e.g. moving user from usersApplied to usersInterview)
    - Job posting closed: A notification is sent when a recruiter deletes a job the user applied to or bookmarked
- User is able to navigate to the job details page when they tap on the status update notification
- User is able to delete the notification by swiping left
- User is able to delete all notifications by clicking on Clear All button
- User is able to search by title, company and type

Error: the Visibility Detector to track unread/read notifications is not really working…