### PR TITLE
Applicant Profile Page: finished resume section

### DIFF
--- a/lib/screens/job_details_screen.dart
+++ b/lib/screens/job_details_screen.dart
@@ -110,8 +110,6 @@ class _JobDetailsScreenState extends State<JobDetailsScreen> {
                     height: 1.2,
                   ),
                   textAlign: TextAlign.center,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
                 ),
                 const SizedBox(height: 6),
                 // Company name


### PR DESCRIPTION
- 2/5 sections done (resume section done)
- Might want to consider optimising the uploading process for resume? (When user chooses a resume it gets uploaded to firebase storage and a dialogue prompts them for the type of resume, if they cancel at this stage, we will remove it from resume storage, perhaps we should only upload it once they provide the type idk)

- Also updated job details screen so that when the job title is long, it doesn’t become a string of ellipsis at the back but still have the full name 